### PR TITLE
Handle missing email confirmation timestamp

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -77,7 +77,7 @@ class User < ApplicationRecord
   end
 
   def email_confirmation_expired?
-    email_confirmation_sent_at < 24.hours.ago
+    email_confirmation_sent_at.nil? || email_confirmation_sent_at < 24.hours.ago
   end
 
   def resend_otp_code

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -54,4 +54,21 @@ RSpec.describe User, type: :model do
       expect(user).to be_valid
     end
   end
+
+  describe '#email_confirmation_expired?' do
+    it 'returns true when no confirmation has been sent' do
+      user = build(:user, email_confirmation_sent_at: nil)
+      expect(user.email_confirmation_expired?).to be true
+    end
+
+    it 'returns true when confirmation was sent more than 24 hours ago' do
+      user = build(:user, email_confirmation_sent_at: 25.hours.ago)
+      expect(user.email_confirmation_expired?).to be true
+    end
+
+    it 'returns false when confirmation was sent within the last 24 hours' do
+      user = build(:user, email_confirmation_sent_at: 1.hour.ago)
+      expect(user.email_confirmation_expired?).to be false
+    end
+  end
 end


### PR DESCRIPTION
## Summary
- Avoid `NilClass` errors when checking if email confirmation expired
- Test email confirmation expiry logic for nil and time-based cases

## Testing
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*
- `bundle exec rspec spec/models/user_spec.rb` *(fails: command not found: rspec)*

------
https://chatgpt.com/codex/tasks/task_e_689547dddc7883288ec97818cd63be26