### PR TITLE
Add JWT service tests

### DIFF
--- a/spec/services/jwt_service_spec.rb
+++ b/spec/services/jwt_service_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe JwtService, type: :service do
+  let(:payload) { { user_id: 1 } }
+
+  describe '.encode' do
+    it 'genera un token JWT válido' do
+      token = described_class.encode(payload)
+      expect(token).to be_a(String)
+      decoded = JWT.decode(token, Rails.application.secret_key_base)[0]
+      expect(decoded['user_id']).to eq(payload[:user_id])
+      expect(decoded).to have_key('exp')
+    end
+  end
+
+  describe '.decode' do
+    it 'recupera el payload original' do
+      token = described_class.encode(payload)
+      decoded_payload = described_class.decode(token)
+      expect(decoded_payload[:user_id]).to eq(payload[:user_id])
+    end
+
+    it 'lanza una excepción legible ante tokens inválidos' do
+      expect { described_class.decode('token.invalido') }.to raise_error(StandardError, /Invalid token/)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add spec for JwtService encode and decode behaviors

## Testing
- `bundle exec rspec spec/services/jwt_service_spec.rb` *(fails: bundler: command not found: rspec)*
- `bundle install` *(fails: Net::HTTPClientException 403 "Forbidden")*


------
https://chatgpt.com/codex/tasks/task_e_6897a515692483288d33775c67adff6b